### PR TITLE
Add CLI and minimal example

### DIFF
--- a/cocktail_shaker/__main__.py
+++ b/cocktail_shaker/__main__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+"""Entrypoint module, in case you use `python -m cocktail_shaker`.
+
+Why does this file exist, and why __main__? For more info, read:
+ - https://www.python.org/dev/peps/pep-0338/
+ - https://docs.python.org/3/using/cmdline.html#cmdoption-m
+"""
+
+from .cli import main
+
+if __name__ == '__main__':
+    main()

--- a/cocktail_shaker/cli.py
+++ b/cocktail_shaker/cli.py
@@ -1,0 +1,17 @@
+
+"""Command line interface for ``cocktail-shaker``."""
+
+import click
+
+__all__ = [
+    'main',
+]
+
+
+@click.group()
+def main():
+    """Run the command line interface for ``cocktail-shaker``."""
+
+
+if __name__ == '__main__':
+    main()

--- a/cocktail_shaker/cli.py
+++ b/cocktail_shaker/cli.py
@@ -1,16 +1,60 @@
+# -*- coding: utf-8 -*-
 
-"""Command line interface for ``cocktail-shaker``."""
+"""Command line interface for ``cocktail-shaker``.
+
+Why does this file exist, and why not put this in ``__main__``? You might
+be tempted to import things from ``__main__`` later, but that will cause
+problems--the code will get executed twice:
+
+- When you run ``python3 -m cocktail_shaker`` python will execute
+  ``__main__.py`` as a script. That means there won't be any
+  ``cocktail_shaker.__main__`` in ``sys.modules``.
+- When you import __main__ it will get executed again (as a module) because
+  there's no ``cocktail_shaker.__main__`` in ``sys.modules``.
+
+.. seealso:: http://click.pocoo.org/7/setuptools/#setuptools-integration
+"""
 
 import click
+
+from .file_handler import FileWriter
+from .functional_group_enumerator import Cocktail
+from .peptide_builder import PeptideMolecule
 
 __all__ = [
     'main',
 ]
 
 
-@click.group()
-def main():
+@click.command()
+@click.argument('length', type=int)
+@click.argument('ligand-library', nargs=-1)
+@click.option('--enable-isomers', is_flag=True)
+@click.option('--include-amino-acids', is_flag=True)
+@click.option('-o', '--output')
+def main(
+    length: int,
+    ligand_library,
+    enable_isomers: bool,
+    include_amino_acids: bool,
+    output,
+):
     """Run the command line interface for ``cocktail-shaker``."""
+    peptide_backbone = PeptideMolecule(length)
+    cocktail = Cocktail(
+        peptide_backbone,
+        ligand_library=ligand_library,
+        enable_isomers=enable_isomers,
+        include_amino_acids=include_amino_acids,
+    )
+    molecules = cocktail.shake()
+
+    if output:
+        name, extension = output.split('.')
+        FileWriter(name=name, molecules=molecules, option=extension)
+    else:
+        for molecule in molecules:
+            click.echo(molecule)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,18 @@ if os.path.exists('README.md'):
 else:
     long_description = 'Cocktail Shaker is drug enumeration and expansion library'
 
+ENTRY_POINTS = {
+    'console_scripts': [
+        'cocktail-shaker = cocktail_shaker.cli:main',
+    ],
+}
+
 # exec
 # ----
 setup(
     name="cocktail_shaker",
     version="1.1.0",
-    packages = ['cocktail_shaker'],
+    packages=['cocktail_shaker'],
     license='MIT',
     author="Suliman Sharif",
     author_email="sharifsuliman1@gmail.com",
@@ -59,5 +65,6 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     test_suite='tests',
-    tests_require=TEST_REQUIREMENTS
+    tests_require=TEST_REQUIREMENTS,
+    entry_points=ENTRY_POINTS,
 )


### PR DESCRIPTION
Closes #35 

From what I could tell in the docs, this is the main workflow. The CLI allows the user to specify the length of the peptide (required), the library (variable length) then some other options as well, then make some outputs.

It uses the `__main__` script to make it available with `python -m cocktail_shaker`

It uses the entry-points in setup.py to make it available as a vanity script `cocktail-shaker`